### PR TITLE
fix: includeComma not being cross-i18n-compatible

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -24,7 +24,7 @@ const AnimatedNumber = ({
   const { ref, inView } = useInView({ triggerOnce: true });
   const keyCount = React.useRef(0);
   const animteTonumberString = includeComma
-    ? Math.abs(animateToNumber).toLocaleString()
+    ? Math.abs(animateToNumber).toLocaleString("en-US")
     : String(Math.abs(animateToNumber));
   const animateToNumbersArr = Array.from(animteTonumberString, Number).map(
     (x, idx) => (isNaN(x) ? animteTonumberString[idx] : x)


### PR DESCRIPTION
Closes #34.

Since some i18n doesn't use comma as a thousand-separator, the locale should be explicitly stated to one which uses comma as a separator (e.g. en-US).

__Before:__
![CleanShot 2022-07-27 at 00 52 08](https://user-images.githubusercontent.com/51714798/181125704-f8cd4800-fd81-4f1d-8341-142fc11bab0c.png)

__After:__
![CleanShot 2022-07-27 at 00 52 49](https://user-images.githubusercontent.com/51714798/181125780-877f1d15-dd40-47f1-a9fa-47344874d1ca.png)

---

__In-Depth:__

The reason the previous failed and displayed an additional 0 is because with my locale (which is Sweden), we use " " as the thousand separator, and when converting the localeString (in this case "10 159") to the array we would get [1, 0, 0, 1, 5, 9] since `Number(" ") = 0`.


