### PR TITLE
Fixed animation glitch because of font-width

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -1,124 +1,191 @@
 import React from "react";
-import { Spring, animated } from "react-spring";
-import { useInView } from "react-intersection-observer";
+import {
+    Spring,
+    animated
+} from "react-spring";
+import {
+    useInView
+} from "react-intersection-observer";
 
 const NUMBERS = [
-  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5,
-  6, 7, 8, 9,
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5,
+    6, 7, 8, 9,
 ];
 
 // utils
 function getRandomIntInclusive(min, max) {
-  min = Math.ceil(min);
-  max = Math.floor(max);
-  return Math.floor(Math.random() * (max - min + 1)) + min;
+    min = Math.ceil(min);
+    max = Math.floor(max);
+    return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
 // lib
 const AnimatedNumber = ({
-  animateToNumber,
-  fontStyle,
-  configs,
-  includeComma,
-}) => {
-  const { ref, inView } = useInView({ triggerOnce: true });
-  const keyCount = React.useRef(0);
-  const animteTonumberString = includeComma
-    ? Math.abs(animateToNumber).toLocaleString("en-US")
-    : String(Math.abs(animateToNumber));
-  const animateToNumbersArr = Array.from(animteTonumberString, Number).map(
-    (x, idx) => (isNaN(x) ? animteTonumberString[idx] : x)
-  );
+        animateToNumber,
+        fontStyle,
+        configs,
+        includeComma,
+    }) => {
+        const {
+            ref,
+            inView
+        } = useInView({
+            triggerOnce: true
+        });
+        const keyCount = React.useRef(0);
+        const animteTonumberString = includeComma ?
+            Math.abs(animateToNumber).toLocaleString("en-US") :
+            String(Math.abs(animateToNumber));
+        const animateToNumbersArr = Array.from(animteTonumberString, Number).map(
+            (x, idx) => (isNaN(x) ? animteTonumberString[idx] : x)
+        );
 
-  const [numberHeight, setNumberHeight] = React.useState(0);
+        const [numberHeight, setNumberHeight] = React.useState(0);
 
-  const numberDivRef = React.useRef(null);
+        const numberDivRef = React.useRef(null);
 
-  const setConfig = (configs, number, index) => {
-    if (typeof configs === "function") {
-      return configs(number, index);
-    }
-    return configs
-      ? configs[getRandomIntInclusive(0, configs.length - 1)]
-      : undefined;
-  };
+        const setConfig = (configs, number, index) => {
+            if (typeof configs === "function") {
+                return configs(number, index);
+            }
+            return configs ?
+                configs[getRandomIntInclusive(0, configs.length - 1)] :
+                undefined;
+        };
 
-  React.useEffect(() => {
-    const height = numberDivRef.current.getClientRects()?.[0]?.height;
-    if (height) {
-      setNumberHeight(height);
-    }
-  }, [animateToNumber, fontStyle]);
 
-  return (
-    <>
-      {numberHeight !== 0 && (
-        <div
-          ref={ref}
-          style={{ display: "flex", flexDirection: "row" }}
-          className="animated-container"
-        >
-          {inView && animateToNumber < 0 && <div style={fontStyle}>-</div>}
-          {inView &&
-            animateToNumbersArr.map((n, index) => {
-              if (typeof n === "string") {
-                return (
-                  <div key={index} style={{ ...fontStyle }}>
-                    {n}
-                  </div>
-                );
-              }
-
-              return (
-                <div
-                  key={index}
-                  style={{
-                    height: numberHeight,
-                    overflow: "hidden",
-                  }}
-                >
-                  <Spring
-                    key={`${keyCount.current++}`}
-                    from={{
-                      transform: "translateY(0px)",
-                    }}
-                    to={{
-                      transform: `translateY(${
-                        -1 * (numberHeight * animateToNumbersArr[index]) -
-                        numberHeight * 20
-                      })`,
-                    }}
-                    config={setConfig(configs, n, index)}
-                  >
-                    {(props) =>
-                      NUMBERS.map((number, i) => (
-                        <animated.div
-                          key={i}
-                          style={{ ...fontStyle,...props }}
-                        >
-                          {number}
-                        </animated.div>
-                      ))
+        React.useEffect(() => {
+            const height = numberDivRef.current.getClientRects()?.[0]?.height;
+            const width = numberDivRef.current.getClientRects()?.[0]?.width;
+            if (height && width) {
+                setNumberHeight(height);
+                setNumberWidth(width);
+            }
+        }, [animateToNumber, fontStyle]);
+        return ( <
+            > {
+                numberHeight !== 0 && ( <
+                    div ref = {
+                        ref
                     }
-                  </Spring>
-                </div>
-              );
-            })}
-        </div>
-      )}
+                    style = {
+                        {
+                            display: "flex",
+                            flexDirection: "row"
+                        }
+                    }
+                    className = "animated-container" >
+                    {
+                        inView && animateToNumber < 0 && < div style = {
+                            fontStyle
+                        } > - < /div>} {
+                            inView &&
+                                animateToNumbersArr.map((n, index) => {
+                                    if (typeof n === "string") {
+                                        return ( <
+                                            div key = {
+                                                index
+                                            }
+                                            style = {
+                                                {
+                                                    ...fontStyle
+                                                }
+                                            } > {
+                                                n
+                                            } <
+                                            /div>
+                                        );
+                                    }
 
-      <div
-        ref={numberDivRef}
-        style={{ position: "absolute", top: -9999, ...fontStyle }}
-      >
-        {0}
-      </div>
-    </>
-  );
-};
+                                    return ( <
+                                        div key = {
+                                            index
+                                        }
+                                        style = {
+                                            {
+                                                height: numberHeight,
+                                                width: numberWidth,
+                                                overflow: "hidden",
+                                                display: "flex",
+                                                alignItems: "center",
+                                                justifyContent: "center",
+                                                textAlign: "center",
+                                            }
+                                        } >
+                                        <
+                                        Spring key = {
+                                            `${keyCount.current++}`
+                                        }
+                                        from = {
+                                            {
+                                                transform: "translateY(0px)",
+                                            }
+                                        }
+                                        to = {
+                                            {
+                                                transform: `translateY(${
+      -1 * numberHeight * animateToNumbersArr[index]
+    }) translateX(${-0.5 * numberWidth})`,
+                                            }
+                                        }
+                                        config = {
+                                            setConfig(configs, n, index)
+                                        }
+                                        delay = {
+                                            index * 150
+                                        } >
+                                        {
+                                            (props) =>
+                                            NUMBERS.map((number, i) => ( <
+                                                animated.div key = {
+                                                    i
+                                                }
+                                                style = {
+                                                    {
+                                                        ...fontStyle,
+                                                        ...props,
+                                                        height: numberHeight,
+                                                        width: numberWidth,
+                                                    }
+                                                } >
+                                                {
+                                                    number
+                                                } <
+                                                /animated.div>
+                                            ))
+                                        } <
+                                        /Spring> <
+                                        /div>
 
-const Enhanced = React.memo(AnimatedNumber, (prevProps, nextProps) => {
-    return prevProps.animateToNumber === nextProps.animateToNumber && prevProps.fontStyle === nextProps.fontStyle && prevProps.includeComma === nextProps.includeComma;
-})
+                                    );
+                                })
+                        } <
+                        /div>
+                    )
+                }
 
-export default Enhanced;
+                <
+                div
+                ref = {
+                    numberDivRef
+                }
+                style = {
+                    {
+                        position: "absolute",
+                        top: -9999,
+                        ...fontStyle
+                    }
+                } >
+                {
+                    0
+                } <
+                /div> <
+                />
+            );
+        };
+
+        const Enhanced = React.memo(AnimatedNumber, (prevProps, nextProps) => {
+            return prevProps.animateToNumber === nextProps.animateToNumber && prevProps.fontStyle === nextProps.fontStyle && prevProps.includeComma === nextProps.includeComma;
+        })
+
+        export default Enhanced;


### PR DESCRIPTION
Solution is to adjust the transform value used in the to prop of the Spring component. Instead of using a fixed value for the translateY transform, you can use a dynamic value that is based on the number being animated. For example, you can use the numberHeight and numberWidth variables to calculate the vertical and horizontal offsets for each number, and then use these values to position the numbers correctly.

Note that in this example, the translateX transform is being used to horizontally center the numbers within their container. This should help to prevent the numbers from overlapping at the end of the animation.