### PR TITLE
add type definitions for alternate configs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,13 @@
 import React from "react";
 import { SpringConfig } from "react-spring";
 
+type configsFn = ({numberValue, index}: {numberValue: number, index: number}) => SpringConfig;
+
 export interface Props {
   animateToNumber: number;
   fontStyle?: React.CSSProperties;
   includeComma?: boolean;
-  configs?: SpringConfig[];
+  configs?: SpringConfig[] | configsFn;
 }
 
 declare const AnimatedNumber: React.FunctionComponent<Props>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import React from "react";
 import { SpringConfig } from "react-spring";
 
-type configsFn = ({numberValue, index}: {numberValue: number, index: number}) => SpringConfig;
+type configsFn = (numberValue: number, index: number) => SpringConfig;
 
 export interface Props {
   animateToNumber: number;


### PR DESCRIPTION
When using the configs as documented in the README typescript compilation fails with:
`Type error: Type '() => Partial<AnimationConfig>' is not assignable to type 'Partial<AnimationConfig>[]'.`

Update the type definitions so it can be used as documented.
