### PR TITLE
fix react-spring dependency overrides

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { SpringConfig } from "react-spring";
+import { SpringConfig } from "@react-spring/web";
 
 export interface Props {
   animateToNumber: number;

--- a/index.jsx
+++ b/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Spring, animated } from "react-spring";
+import { Spring, animated } from "@react-spring/web";
 import { useInView } from "react-intersection-observer";
 
 const NUMBERS = [

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "react-intersection-observer": "^8.33.1",
-    "react-spring": "^9.4.5"
+    "@react-spring/web": "^9.4.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.11.6",


### PR DESCRIPTION
currently `react-animated-numbers` depends on `react-spring` but I believe it should depend on `@react-spring/web` instead.

When you depend on the former you see the below during depencency resolution. After updating to the later you don't see **any** of these warnings.

`@react-spring/web` also appears to be the reccomended way of installing `react-spring` as seen [here](https://www.react-spring.dev) and [here](https://www.react-spring.dev/docs/getting-started#install)

```
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: react-konva@16.8.6
npm WARN Found: react@18.2.0
npm WARN node_modules/react
npm WARN   peer react@"^16.8.0 || ^17.0.0 || ^18.0.0" from @react-spring/animated@9.6.1
npm WARN   node_modules/@react-spring/animated
npm WARN     @react-spring/animated@"~9.6.1" from @react-spring/core@9.6.1
npm WARN     node_modules/@react-spring/core
npm WARN     5 more (@react-spring/native, @react-spring/three, ...)
npm WARN   25 more (@react-spring/core, @react-spring/native, ...)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer react@"16.8.x" from react-konva@16.8.6
npm WARN node_modules/react-spring/node_modules/react-konva
npm WARN   peer react-konva@"^16.8.0 || ^17.0.0" from @react-spring/konva@9.6.1
npm WARN   node_modules/react-spring/node_modules/@react-spring/konva
npm WARN 
npm WARN Conflicting peer dependency: react@16.8.6
npm WARN node_modules/react
npm WARN   peer react@"16.8.x" from react-konva@16.8.6
npm WARN   node_modules/react-spring/node_modules/react-konva
npm WARN     peer react-konva@"^16.8.0 || ^17.0.0" from @react-spring/konva@9.6.1
npm WARN     node_modules/react-spring/node_modules/@react-spring/konva
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: react-konva@16.8.6
npm WARN Found: react-dom@18.2.0
npm WARN node_modules/react-dom
npm WARN   peer react-dom@"^16.8.0 || ^17.0.0 || ^18.0.0" from @react-spring/web@9.6.1
npm WARN   node_modules/@react-spring/web
npm WARN     @react-spring/web@"~9.6.1" from react-spring@9.6.1
npm WARN     node_modules/react-spring
npm WARN   8 more (@react-spring/zdog, @react-three/fiber, next, ...)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer react-dom@"16.8.x" from react-konva@16.8.6
npm WARN node_modules/react-spring/node_modules/react-konva
npm WARN   peer react-konva@"^16.8.0 || ^17.0.0" from @react-spring/konva@9.6.1
npm WARN   node_modules/react-spring/node_modules/@react-spring/konva
npm WARN 
npm WARN Conflicting peer dependency: react-dom@16.8.6
npm WARN node_modules/react-dom
npm WARN   peer react-dom@"16.8.x" from react-konva@16.8.6
npm WARN   node_modules/react-spring/node_modules/react-konva
npm WARN     peer react-konva@"^16.8.0 || ^17.0.0" from @react-spring/konva@9.6.1
npm WARN     node_modules/react-spring/node_modules/@react-spring/konva
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: react-reconciler@0.20.4
npm WARN Found: react@18.2.0
npm WARN node_modules/react
npm WARN   peer react@"^16.8.0 || ^17.0.0 || ^18.0.0" from @react-spring/animated@9.6.1
npm WARN   node_modules/@react-spring/animated
npm WARN     @react-spring/animated@"~9.6.1" from @react-spring/core@9.6.1
npm WARN     node_modules/@react-spring/core
npm WARN     5 more (@react-spring/native, @react-spring/three, ...)
npm WARN   25 more (@react-spring/core, @react-spring/native, ...)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer react@"^16.0.0" from react-reconciler@0.20.4
npm WARN node_modules/react-zdog/node_modules/react-reconciler
npm WARN   react-reconciler@"^0.20.4" from react-zdog@1.0.11
npm WARN   node_modules/react-zdog
npm WARN 
npm WARN Conflicting peer dependency: react@16.14.0
npm WARN node_modules/react
npm WARN   peer react@"^16.0.0" from react-reconciler@0.20.4
npm WARN   node_modules/react-zdog/node_modules/react-reconciler
npm WARN     react-reconciler@"^0.20.4" from react-zdog@1.0.11
npm WARN     node_modules/react-zdog
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: react-reconciler@0.20.4
npm WARN Found: react@18.2.0
npm WARN node_modules/react
npm WARN   peer react@"^16.8.0 || ^17.0.0 || ^18.0.0" from @react-spring/animated@9.6.1
npm WARN   node_modules/@react-spring/animated
npm WARN     @react-spring/animated@"~9.6.1" from @react-spring/core@9.6.1
npm WARN     node_modules/@react-spring/core
npm WARN     5 more (@react-spring/native, @react-spring/three, ...)
npm WARN   25 more (@react-spring/core, @react-spring/native, ...)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer react@"^16.0.0" from react-reconciler@0.20.4
npm WARN node_modules/react-spring/node_modules/react-konva/node_modules/react-reconciler
npm WARN   react-reconciler@"^0.20.4" from react-konva@16.8.6
npm WARN   node_modules/react-spring/node_modules/react-konva
npm WARN 
npm WARN Conflicting peer dependency: react@16.14.0
npm WARN node_modules/react
npm WARN   peer react@"^16.0.0" from react-reconciler@0.20.4
npm WARN   node_modules/react-spring/node_modules/react-konva/node_modules/react-reconciler
npm WARN     react-reconciler@"^0.20.4" from react-konva@16.8.6
npm WARN     node_modules/react-spring/node_modules/react-konva
```
